### PR TITLE
Add Authelia to Swarm

### DIFF
--- a/authelia/authelia.yml
+++ b/authelia/authelia.yml
@@ -1,0 +1,56 @@
+# Authelia Recipe
+# /share/appdata/config/authelia/authelia.yml
+
+#This example comments out the REDIS and all 2FA.  Docs can be found here: https://www.authelia.com/docs/
+
+
+version: "3.4"
+
+
+#all secrets kept in secrets folder by design.
+secrets:
+  AUTHELIA_JWT_SECRET:
+    file: "/share/appdata/config/secrets/AUTHELIA_JWT_SECRET.secret"
+  AUTHELIA_SESSION_SECRET:
+    file: "/share/appdata/config/secrets/AUTHELIA_SESSION_SECRET.secret"
+#  AUTHELIA_SESSION_REDIS_PASSWORD:
+#    file: "/share/appdata/config/secrets/AUTHELIA_SESSION_REDIS_PASSWORD.secret"
+  AUTHELIA_NOTIFIER_SMTP_PASSWORD:
+    file: "/share/appdata/config/secrets/AUTHELIA_NOTIFIER_SMTP_PASSWORD.secret"
+
+services:
+  authelia:
+    image: authelia/authelia
+    secrets:
+      - AUTHELIA_JWT_SECRET
+      - AUTHELIA_SESSION_SECRET
+#      - AUTHELIA_SESSION_REDIS_PASSWORD
+      - AUTHELIA_NOTIFIER_SMTP_PASSWORD
+    environment:
+      - TZ=America/New_York
+    volumes:
+      - /share/appdata/config/authelia:/var/lib/authelia
+      - /share/appdata/config/authelia/users_database.yml:/etc/authelia/users_database.yml
+      - /share/appdata/config/authelia/configuration.yml:/etc/authelia/configuration.yml:ro
+    networks:
+      - traefik_public
+      - internal
+    deploy:
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.authelia.entrypoints=https"
+        - "traefik.http.routers.authelia.rule=Host(`login.domain.tld`)"
+        - "traefik.http.routers.authelia.tls.certresolver=cloudflare"
+        - "traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=https://login.domain.tld"
+        - "traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true"
+        - "traefik.http.middlewares.authelia.forwardauth.authResponseHeaders=Remote-User, Remote-Groups"
+        - "traefik.http.services.authelia.loadbalancer.server.port=9091"
+        
+networks:
+  traefik_public:
+    external: true
+  internal:
+    driver: overlay
+    ipam:
+      config:
+        - subnet: 172.16.49.0/24   

--- a/authelia/configuration.yml
+++ b/authelia/configuration.yml
@@ -1,0 +1,74 @@
+###############################################################
+#                   Authelia configuration                    #
+###############################################################
+# Authelia Recipe
+# /share/appdata/config/authelia/configuration.yml
+
+host: 0.0.0.0
+port: 9091
+log_level: debug
+# This secret can also be set using the env variables AUTHELIA_JWT_SECRET
+jwt_secret: AUTHELIA_JWT_SECRET
+#whatever you want the default redirect to be if you login from login.domain.tld
+default_redirection_url: https://home.domain.tld 
+
+#totp:
+#  issuer: authelia.com
+
+#duo_api:
+#  hostname: api-123456789.example.com
+#  integration_key: ABCDEF
+#  # This secret can also be set using the env variables AUTHELIA_DUO_API_SECRET_KEY
+#  secret_key: 1234567890abcdefghifjkl
+
+authentication_backend:
+  file:
+    path: /etc/authelia/users_database.yml
+
+access_control:
+  default_policy: deny
+  rules:
+    - domain: "*.domain.tld"
+      subject:
+        - "group:admins"
+      policy: one_factor
+
+session:
+  name: authelia_session
+  # This secret can also be set using the env variables AUTHELIA_SESSION_SECRET
+  secret: AUTHELIA_SESSION_SECRET
+  expiration: 7200 # 2 hours
+  inactivity: 1800 # 30 minutes
+  domain: domain.tld # Should match whatever your root protected domain is
+
+#  redis:
+#    host: redis
+#    port: 6379
+    # This secret can also be set using the env variables AUTHELIA_SESSION_REDIS_PASSWORD
+#    password: AUTHELIA_SESSION_REDIS_PASSWORD_FILE
+
+regulation:
+  max_retries: 3
+  find_time: 120
+  ban_time: 300
+
+storage:
+  local:
+    path: /var/lib/authelia/db.sqlite3
+
+#see https://www.authelia.com/docs/configuration/notifier/smtp.html
+notifier:
+  disable_startup_check: true
+  smtp:
+    username: youremail@email.com
+    # This secret can also be set using the env variables AUTHELIA_NOTIFIER_SMTP_PASSWORD
+    password: AUTHELIA_NOTIFIER_SMTP_PASSWORD
+    host: host
+    port: port
+    sender: admin@domain.tld
+    # Subject configuration of the emails sent.
+    # {title} is replaced by the text from the notifier
+    subject: "[Authelia] {title}"
+    ## disable_require_tls: false
+    ## disable_verify_cert: false
+    ## trusted_cert: ""

--- a/authelia/forward-auth.yml
+++ b/authelia/forward-auth.yml
@@ -1,0 +1,23 @@
+##Replace your Dynamic Traefik Forward-Auth file with the following:
+
+# To secure your services, either of the following labels to your service:
+
+# - "traefik.http.routers.SERVICE.middlewares=authelia@docker" 
+#OR
+# - "traefik.http.routers.SERVICE.middlewares=forward-auth@file"
+
+# Traefik Dynamic Configuration
+# Middleware: Forward Auth
+# Host Path: /share/appdata/config/traefik/dynamic/forward-auth.yaml
+# Internal Path: /etc/traefik/dynamic/forward-auth.yaml
+
+http:
+  middlewares:
+    forward-auth:
+      forwardAuth:
+        address: "http://authelia:9091/api/verify?rd=https://login.domain.tld/"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - "Remote-User"
+          - "Remote-Groups"
+          

--- a/authelia/users_database.yml
+++ b/authelia/users_database.yml
@@ -1,0 +1,14 @@
+# Authelia Recipe
+# /share/appdata/config/authelia/users_database.yml
+
+#This is default for file authentication.  Go to https://www.authelia.com/docs/configuration/authentication/file.html for more info on how to create new users.
+
+users:
+  john:
+    displayname: "John Doe"
+    password: "$argon2id$v=19$m=65536,t=3,p=2$BpLnfgDsc2WD8F2q$o/vzA4myCqZZ36bUGsDY//8mKUYNZZaR0t4MFFSs+iM"
+    email: john.doe@authelia.com
+    groups:
+      - admins
+      - dev
+      


### PR DESCRIPTION
Includes Authelia docker-compose, configuration files, and changes to Traefik forward-auth middleware.  

This uses a simple config: file authentication (not LDAP), sqlite (instead of db container), no 2FA (but this is simple enough for a user to set up on their own.